### PR TITLE
Set a default value for mia_user_path in configuration window

### DIFF
--- a/python/populse_mia/main.py
+++ b/python/populse_mia/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*- #
 """The first module used at the runtime of mia.
 
 Basically, this module is dedicated to the initialisation of the basic
@@ -499,6 +498,8 @@ def main():
                                 "directories): ")
             msg.file_line_edit = QLineEdit()
             msg.file_line_edit.setFixedWidth(400)
+            default_directory = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            msg.file_line_edit.setText(default_directory)
             file_button = QPushButton("Browse")
             file_button.clicked.connect(partial(_browse_mia_path, msg))
             vbox_layout.addWidget(file_label)


### PR DESCRIPTION
When starting populse_mia for the first time without any configuration file, an window is opened asking for a path. If I understand what is expected in that path, we can provide a default path value using module file parent. This allow for new user to simply choose Ok button to start.