### PR TITLE
Activate developer mode when casa_distro environment is detected

### DIFF
--- a/python/populse_mia/main.py
+++ b/python/populse_mia/main.py
@@ -52,6 +52,10 @@ if not os.path.dirname(os.path.dirname(
         os.path.realpath(__file__))))
     DEV_MODE = True
 
+elif 'CASA_DISTRO' in os.environ:
+    # If the casa distro developpement environment is detected,
+    # developer mode is activated.
+    DEV_MODE = True
 else:  # "user" mode
     DEV_MODE = False
 


### PR DESCRIPTION
In BrainVISA developpment environment, `populse_mia` parent directory is added to `sys.path` so it is configured to be in user mode. I added a casa_distro specific test to set developer mode in that case.